### PR TITLE
Add PR preview environments with SST

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,72 @@
+name: SST Preview Deployments
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  deploy:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.11.1
+      - run: npm ci
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.STAGING_AWS_REGION }}
+      - name: Install SST
+        run: |
+          curl -fsSL https://ion.sst.dev/install | bash
+      - name: Deploy preview
+        run: npx sst deploy --stage pr-${{ github.event.number }}
+        env:
+          DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
+          AUTH_JWT_SECRET: ${{ secrets.AUTH_JWT_SECRET }}
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        env:
+          DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
+        with:
+          script: |
+            const pr = context.issue.number;
+            const url = `https://pr-${pr}-nx-sst-next.${process.env.DOMAIN_NAME}`;
+            const body = `Preview environment available: ${url}`;
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: pr,
+              body,
+            });
+
+  destroy:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.11.1
+      - run: npm ci
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.STAGING_AWS_REGION }}
+      - name: Install SST
+        run: |
+          curl -fsSL https://ion.sst.dev/install | bash
+      - name: Remove preview
+        run: npx sst remove --stage pr-${{ github.event.number }}
+        env:
+          DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
+          AUTH_JWT_SECRET: ${{ secrets.AUTH_JWT_SECRET }}

--- a/README.md
+++ b/README.md
@@ -24,3 +24,21 @@ Or simply using NX
 npx nx run admin:deploy:staging
 npx nx run admin:deploy:production
 ```
+
+## GitHub Secrets
+
+The GitHub Actions workflow requires several secrets to deploy preview
+environments.  Create these secrets in your repository under
+`Settings` → `Secrets and variables` → `Actions`.
+
+| Secret | Description |
+| ------ | ----------- |
+| `STAGING_AWS_ACCESS_KEY_ID` | AWS access key for deploying previews |
+| `STAGING_AWS_SECRET_ACCESS_KEY` | AWS secret key for deploying previews |
+| `STAGING_AWS_REGION` | AWS region where the preview stack will be created |
+| `DOMAIN_NAME` | Root domain used for preview URLs |
+| `AUTH_JWT_SECRET` | JWT secret for the SST app |
+
+These secrets allow the `.github/workflows/preview.yml` workflow to deploy a
+preview stack for each pull request and comment the URL on the PR. When the pull
+request is closed the stack is automatically removed.


### PR DESCRIPTION
## Summary
- deploy SST preview environments with GitHub Actions
- tear down the environment when pull requests close
- document the required GitHub secrets

## Testing
- `npm test` *(fails: nx not found)*
